### PR TITLE
Add Docker support and production env

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,3 @@
+APP_ENV=prod
+APP_SECRET=ChangeMe
+DATABASE_URL="mysql://symfony:symfony@db:3306/app?serverVersion=mariadb-10.5"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM php:8.1-apache
+
+ENV APACHE_DOCUMENT_ROOT=/var/www/html/public
+
+RUN apt-get update \
+    && apt-get install -y git zip unzip libzip-dev \
+    && docker-php-ext-install pdo pdo_mysql \
+    && a2enmod rewrite \
+    && sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/000-default.conf
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /var/www/html
+COPY . .
+
+RUN composer install --no-dev --optimize-autoloader
+
+EXPOSE 80
+CMD ["apache2-foreground"]

--- a/README.md
+++ b/README.md
@@ -13,3 +13,13 @@ Lancez les migrations en tapant php bin/console doctrine:migrations:migrate
 Lancez les fixtures en tapant php bin/console doctrine:fixtures:load
 
 Lancez le serveur avec php bin/console server:run
+
+## Comment exécuter le projet
+
+Pour démarrer l'application avec Docker, assurez-vous d'être à la racine du projet puis exécutez :
+
+```bash
+docker-compose up --build
+```
+
+L'application sera alors accessible sur `http://localhost:8000`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+services:
+  db:
+    image: mariadb:10.5
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: app
+      MYSQL_USER: symfony
+      MYSQL_PASSWORD: symfony
+    volumes:
+      - db-data:/var/lib/mysql
+
+  app:
+    build: .
+    ports:
+      - "8000:80"
+    depends_on:
+      - db
+    environment:
+      DATABASE_URL: "mysql://symfony:symfony@db:3306/app?serverVersion=mariadb-10.5"
+    volumes:
+      - .:/var/www/html
+
+volumes:
+  db-data:


### PR DESCRIPTION
## Summary
- add Dockerfile for Symfony app
- setup docker-compose with MariaDB
- add production environment config file
- document Docker usage in README

## Testing
- `composer install` *(fails: php version requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68717ec2e848832aa23d77407a8098e4