### PR TITLE
Add login form handling and article route protection

### DIFF
--- a/src/Controller/BlogController.php
+++ b/src/Controller/BlogController.php
@@ -68,6 +68,7 @@ class BlogController extends AbstractController
      * @Route("/blog/{id}/edit", name="blog_edit")
      */
     public function addArticle(Article $article = null, Request $request, EntityManagerInterface $manager, FileUploader $fileuploader) {
+        $this->denyAccessUnlessGranted('ROLE_USER');
 
         if(!$article){
             $article = new Article();

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -11,6 +11,7 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
 
 class SecurityController extends AbstractController
@@ -50,9 +51,15 @@ class SecurityController extends AbstractController
     /**
      * @Route("/connexion", name="security_login")
      */
-    public function login()
+    public function login(AuthenticationUtils $authenticationUtils)
     {
-        return $this->render('security/login.html.twig');
+        $error = $authenticationUtils->getLastAuthenticationError();
+        $lastUsername = $authenticationUtils->getLastUsername();
+
+        return $this->render('security/login.html.twig', [
+            'last_username' => $lastUsername,
+            'error' => $error,
+        ]);
     }
 
     /**

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -2,12 +2,15 @@
 
 {% block body %}
 
+    {% if error %}
+        <div class="alert alert-danger">{{ error.messageKey|trans(error.messageData, 'security') }}</div>
+    {% endif %}
     <form action="{{ path('security_login') }}" method="post">
         <fieldset>
             <legend><i class="fa fa-lock" aria-hidden="true"></i> Connexion </legend>
             <div class="form-group">
                 <label for="username">Email/user</label>
-                <input type="text" id="username" required name="_username" class="form-control"/>
+                <input type="text" id="username" required name="_username" value="{{ last_username }}" class="form-control"/>
             </div>
             <div class="form-group">
                 <label for="password">Mot de passe </label>


### PR DESCRIPTION
## Summary
- enhance `SecurityController::login` with error handling and username retention
- show login errors in template and fill username
- restrict new/edit article routes to authenticated users

## Testing
- `php bin/phpunit -v` *(fails: Unable to find the `simple-phpunit.php` script)*

------
https://chatgpt.com/codex/tasks/task_e_68717e9778fc832aadbe530e6a1a517e