### PR TITLE
Add admin backoffice

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -3,8 +3,11 @@
 namespace App\Controller;
 
 use App\Entity\User;
+use App\Entity\Article;
 use App\Form\EditUserType;
 use App\Repository\UserRepository;
+use App\Repository\ArticleRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -20,9 +23,7 @@ class AdminController extends AbstractController
      */
     public function index(): Response
     {
-        return $this->render('admin/users.html.twig', [
-            'controller_name' => 'AdminController',
-        ]);
+        return $this->render('admin/index.html.twig');
     }
 
     /**
@@ -62,5 +63,34 @@ class AdminController extends AbstractController
         return $this->render('admin/userEdit.html.twig', [
             'userForm' => $form->createView()
             ]);
+    }
+
+    /**
+     * Liste des articles
+     *
+     * @Route("/articles", name="articles")
+     */
+    public function articlesList(ArticleRepository $repo)
+    {
+        $articles = $repo->findAll();
+
+        return $this->render('admin/articles.html.twig', [
+            'articles' => $articles
+        ]);
+    }
+
+    /**
+     * Supprimer un article
+     *
+     * @Route("/article/delete/{id}", name="delete_article")
+     */
+    public function deleteArticle(Article $article, EntityManagerInterface $em): Response
+    {
+        $em->remove($article);
+        $em->flush();
+
+        $this->addFlash('message', 'Article supprimé');
+
+        return $this->redirectToRoute('admin_articles');
     }
 }

--- a/templates/admin/articles.html.twig
+++ b/templates/admin/articles.html.twig
@@ -1,0 +1,30 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+<h1>Liste des articles</h1>
+<table class="table">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Titre</th>
+            <th>Auteur</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for article in articles %}
+        <tr>
+            <td>{{ article.id }}</td>
+            <td>{{ article.title }}</td>
+            <td>{{ article.user.username }}</td>
+            <td>
+                <a class="btn btn-warning" href="{{ path('blog_edit', {'id': article.id}) }}">Éditer</a>
+                <a class="btn btn-danger" href="{{ path('admin_delete_article', {'id': article.id}) }}">Supprimer</a>
+            </td>
+        </tr>
+    {% else %}
+        <tr><td colspan="4">Aucun article</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/templates/admin/index.html.twig
+++ b/templates/admin/index.html.twig
@@ -1,20 +1,9 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Hello AdminController!{% endblock %}
-
 {% block body %}
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; font: 18px/1.5 sans-serif; }
-    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
-</style>
-
-<div class="example-wrapper">
-    <h1>Hello {{ controller_name }}! ✅</h1>
-
-    This friendly message is coming from:
-    <ul>
-        <li>Your controller at <code><a href="{{ 'C:/wamp64/www/symfony/Blog/src/Controller/AdminController.php'|file_link(0) }}">src/Controller/AdminController.php</a></code></li>
-        <li>Your template at <code><a href="{{ 'C:/wamp64/www/symfony/Blog/templates/admin/index.html.twig'|file_link(0) }}">templates/admin/index.html.twig</a></code></li>
-    </ul>
-</div>
+<h1>Administration</h1>
+<ul>
+    <li><a href="{{ path('admin_users') }}">Gestion des utilisateurs</a></li>
+    <li><a href="{{ path('admin_articles') }}">Gestion des articles</a></li>
+</ul>
 {% endblock %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -26,7 +26,7 @@
                 <li class="nav-item"><a class="nav-link" href="{{ path('security_login') }}"> Connexion </a></li>
                 <li class="nav-item"><a class="nav-link" href="{{ path('security_registration') }}"> Inscription </a></li>
                 {% elseif is_granted('ROLE_ADMIN') %}
-                <li class="nav-item"><a class="nav-link" href="{{ path('admin_users') }}"> Admin </a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ path('admin_index') }}"> Admin </a></li>
                 <li class="nav-item"><a class="nav-link" href="{{ path('security_logout') }}"> Déconnexion </a></li>
                 {% else %}   
                 <li class="nav-item"><a class="nav-link" href="{{ path('security_logout') }}"> Déconnexion </a></li>


### PR DESCRIPTION
## Summary
- add routes to manage articles in AdminController
- add backoffice templates for admin index and article list
- hook admin navigation link to new dashboard

## Testing
- `composer install -n --prefer-dist` *(fails: your php version does not satisfy requirements)*
- `php bin/console lint:twig templates` *(fails: vendor autoload not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68717ea3f5a0832abe3b9fac319ca0fb