### PR TITLE
Update dependencies for PHP 8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=8.3",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "composer/package-versions-deprecated": "1.11.99.1",
@@ -12,7 +12,8 @@
         "doctrine/doctrine-bundle": "^2.3",
         "doctrine/doctrine-migrations-bundle": "^3.1",
         "doctrine/orm": "^2.8",
-        "fzaninotto/faker": "^1.9",
+        "laminas/laminas-code": "^5.0",
+        "fakerphp/faker": "^1.21",
         "phpdocumentor/reflection-docblock": "^5.2",
         "sensio/framework-extra-bundle": "^5.1",
         "symfony/asset": "5.2.*",


### PR DESCRIPTION
## Summary
- bump PHP requirement to 8.3
- replace deprecated `fzaninotto/faker` by `fakerphp/faker`
- require `laminas/laminas-code` ^5.0

## Testing
- `phpunit --version` *(fails: command not found)*
- `composer install --no-interaction --no-progress` *(fails: lock file conflicts with updated requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68718644716c832a82169d80e1f4ce37